### PR TITLE
Injection support

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+Copyright (c) 2013-2015 StrongLoop, Inc.
+
+strong-pack uses a dual license model.
+
+You may use this library under the terms of the [Artistic 2.0 license][],
+or under the terms of the [StrongLoop Subscription Agreement][].
+
+[Artistic 2.0 license]: http://opensource.org/licenses/Artistic-2.0
+[StrongLoop Subscription Agreement]: http://strongloop.com/license

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ pump(appTar, gz, tgz, function(err) {
 
 ### License
 
-[Artistic License 2.0](https://opensource.org/licenses/Artistic-2.0)
+This module is dual licensed and can be used under the terms of either:
+ * [Artistic 2.0 License](https://opensource.org/licenses/Artistic-2.0)
+ * [StrongLoop Subscription Agreement](http://strongloop.com/license)
 
 ---
 Copyright &copy; 2015, StrongLoop, an IBM Company

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ is like `npm pack`, but it does **not** honour `.npmignore` and `.gitignore`.
 
 ### Usage
 
+The strong-pack module exports a single function.
+
+#### `pack(dirname)`
+ * arguments:
+   * `dirname` is the path to a node module.
+ * return:
+   * a readable stream containing the tar stream, rooted in `package/` just like
+    `npm pack`.
+
+The readable stream that is returned is a `tar-stream` pack stream, which has
+additional methods on it, including `.entry()` which can be used for injecting
+files directly into the tar archive without having to create them on disk first.
+See the [tar-stream docs](https://github.com/mafintosh/tar-stream#packing) for
+more details.
+
+#### Example
+
 The following example is similar to running `npm pack path/to/app` if npm
 ignored all of the normal rules for ignoring/including files.
 
@@ -16,17 +33,22 @@ var gz = require('zlib').Gzip();
 var pack = require('strong-pack');
 var tgz = fs.createWriteStream('app.tgz', 'binary');
 var appTar = pack('path/to/app');
-// using pipe
+
+// inject a file directly into the tar stream without creating a file on disk
+appTar.entry({name: 'package/.injected.json'},
+             JSON.stringify({key: 'secret'}) + '\n');
+
+// Using pipe
+// don't forget to handle errors and clean up ALL your streams!
 appTar.pipe(gz).pipe(tgz);
-// using pump
+
+// Using pump
+// streams get cleaned up for you, only one place to check for an error
 var pump = require('pump');
 pump(appTar, gz, tgz, function(err) {
-  // done! don't forget to check for an error!
+  // err || done! don't forget to check for an error!
 });
 ```
-
-#### Using pump
-
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "devDependencies": {
     "eslint": "^1.9.0",
     "eslint-config-strongloop": "^1.0.0",
-    "tap": "^2.2.0"
+    "tap": "^2.2.0",
+    "tar": "^2.2.1"
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "fstream": "^1.0.8",
-    "tar": "^2.2.1"
+    "tar-fs": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/strongloop/strong-pack#readme",
   "devDependencies": {
+    "concat-stream": "^1.5.1",
     "eslint": "^1.9.0",
     "eslint-config-strongloop": "^1.0.0",
     "tap": "^2.2.0",

--- a/test/test-inject.js
+++ b/test/test-inject.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var concat = require('concat-stream');
+var fs = require('fs');
+var pack = require('../');
+var path = require('path');
+var tar = require('tar');
+var test = require('tap').test;
+
+var ignoredAppRoot = path.join(__dirname, 'fixtures', 'ignored-app');
+var expectedFiles = [
+  'package',
+  'package/.gitignore',
+  'package/.npmignore',
+  'package/node_modules',
+  'package/node_modules/.bin',
+  'package/node_modules/.bin/foo',
+  'package/node_modules/foo',
+  'package/node_modules/foo/.gitignore',
+  'package/node_modules/foo/.npmignore',
+  'package/node_modules/foo/cmd.js',
+  'package/node_modules/foo/node_modules',
+  'package/node_modules/foo/node_modules/bar',
+  'package/node_modules/foo/node_modules/bar/.gitignore',
+  'package/node_modules/foo/node_modules/bar/.npmignore',
+  'package/node_modules/foo/node_modules/bar/index.js',
+  'package/node_modules/foo/node_modules/bar/package.json',
+  'package/node_modules/foo/package.json',
+  'package/package.json',
+  'package/.injected.json',
+  'package2/.injected.json',
+].sort();
+
+test('ensure injected file does not exist', function(t) {
+  t.ok(!fs.existsSync(path.resolve(ignoredAppRoot, '.injected.json')));
+  t.end();
+});
+
+test('tar stream with injected file', {todo: false}, function(t) {
+  var injectedPath = '.injected.json';
+  var injectedContent = JSON.stringify({
+    key1: 'value1',
+    json: true,
+  });
+  var actualFiles = {};
+  var tarPack = pack(ignoredAppRoot);
+  tarPack.entry({name: 'package/' + injectedPath}, injectedContent);
+  tarPack.entry({name: 'package2/' + injectedPath}, injectedContent);
+
+  return tarPack.pipe(tar.Parse())
+    .on('error', t.ifErr)
+    .on('entry', visit)
+    .on('end', verify);
+
+  function visit(entry) {
+    actualFiles[entry.path] = true;
+    if (entry.path === 'package/' + injectedPath) {
+      entry.pipe(concat(function(d) {
+        actualFiles[entry.path] = d.toString('utf8');
+      }));
+    }
+  }
+
+  function verify() {
+    var paths = Object.keys(actualFiles).sort();
+    var actualContent = actualFiles['package/' + injectedPath];
+    t.same(paths, expectedFiles, 'includes injected file path');
+    t.same(actualContent, injectedContent, 'includes injected file path');
+    t.end();
+  }
+});

--- a/test/test-pack.js
+++ b/test/test-pack.js
@@ -7,24 +7,25 @@ var test = require('tap').test;
 
 var ignoredAppRoot = path.join(__dirname, 'fixtures', 'ignored-app');
 var ignoredAppFiles = [
-  'ignored-app/.gitignore',
-  'ignored-app/.npmignore',
-  'ignored-app/node_modules/',
-  'ignored-app/node_modules/.bin/',
-  'ignored-app/node_modules/.bin/foo',
-  'ignored-app/node_modules/foo/',
-  'ignored-app/node_modules/foo/.gitignore',
-  'ignored-app/node_modules/foo/.npmignore',
-  'ignored-app/node_modules/foo/cmd.js',
-  'ignored-app/node_modules/foo/node_modules/',
-  'ignored-app/node_modules/foo/node_modules/bar/',
-  'ignored-app/node_modules/foo/node_modules/bar/.gitignore',
-  'ignored-app/node_modules/foo/node_modules/bar/.npmignore',
+  'package',
+  'package/.gitignore',
+  'package/.npmignore',
+  'package/node_modules',
+  'package/node_modules/.bin',
+  'package/node_modules/.bin/foo',
+  'package/node_modules/foo',
+  'package/node_modules/foo/.gitignore',
+  'package/node_modules/foo/.npmignore',
+  'package/node_modules/foo/cmd.js',
+  'package/node_modules/foo/node_modules',
+  'package/node_modules/foo/node_modules/bar',
+  'package/node_modules/foo/node_modules/bar/.gitignore',
+  'package/node_modules/foo/node_modules/bar/.npmignore',
   // this is where bar/.svn/entries would be if it wasn't ignored
-  'ignored-app/node_modules/foo/node_modules/bar/index.js',
-  'ignored-app/node_modules/foo/node_modules/bar/package.json',
-  'ignored-app/node_modules/foo/package.json',
-  'ignored-app/package.json',
+  'package/node_modules/foo/node_modules/bar/index.js',
+  'package/node_modules/foo/node_modules/bar/package.json',
+  'package/node_modules/foo/package.json',
+  'package/package.json',
 ];
 
 test('returns a tar stream of everything', function(t) {
@@ -40,7 +41,7 @@ test('returns a tar stream of everything', function(t) {
   }
 
   function verify() {
-    t.same(visit.paths, ignoredAppFiles, 'all expected paths present');
+    t.same(visit.paths.sort(), ignoredAppFiles, 'all expected paths present');
     t.end();
   }
 });


### PR DESCRIPTION
@sam-github @pthieu I ended up having to switch to a different tar implementation to get this working.

Now that it is working, though, I'm not entirely happy with the API:

``` js
var pack = require('strong-pack');
var appTar = pack('path/to/app', {
  injections: [
    {path: '.injected.json', body: JSON.stringify('some json')},
  ]
});
appTar.pipe(gz).pipe(tgz);
```

Because of the change to the underlying tar implementation, there's actually an API already provided that might be just as convenient - or even more convenient:

``` js
var pack = require('strong-pack');
var appTar = pack('path/to/app');
appTar.entry({name: 'package/.injected.json'}, JSON.stringify('some json'));
appTar.pipe(gz).pipe(tgz);
```

Connect to strongloop-internal/scrum-nodeops#1015
