### PR TITLE
fix bad permissions when used on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,17 @@ var FILTER = filterize([
   /^\._/,
 ]);
 
+// If we are running on Windows there won't be any permission bits set so we
+// have to pretend. These get bitwise OR'd with the actual permissions, so we
+// use 0 for platforms that will have real bits already.
+var DMODE = /win32/.test(process.platform) ? parseInt('755', 8) : 0;
+var FMODE = /win32/.test(process.platform) ? parseInt('644', 8) : 0;
+
 function pack(folder) {
   var tarPack = tar.pack(folder, {
     ignore: FILTER,
+    fmode: FMODE,
+    dmode: DMODE,
     map: function(header) {
       if (header.name === '.') {
         header.name = 'package';


### PR DESCRIPTION
The problem is that Windows doesn't have the type of permissions bits
that tar uses, and tar-fs doesn't provide a default since it expects to
enforce a default on the unpacking side. The tarballs produced by
strong-pack are likely to be unpacked by npm, which assumes proper
permissions are already set.

This should fix strongloop/strong-pm#317
